### PR TITLE
Formats object count with commas

### DIFF
--- a/EverythingToolbar/Converters/SearchResultsCountConverter.cs
+++ b/EverythingToolbar/Converters/SearchResultsCountConverter.cs
@@ -13,8 +13,10 @@ namespace EverythingToolbar.Converters
             if (value == null)
                 return "";
 
+            string formattedValue = ((int)value).ToString("N0", culture);
+
             string suffix = (int)value == 1 ? Resources.SearchResult : Resources.SearchResults;
-            return $"{value} {suffix}";
+            return $"{formattedValue} {suffix}";
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
Formats the object count to include commas when appropriate by region. Makes the count more readable when there are several thousand/million objects found.