### PR TITLE
Hide after clicking a program icon

### DIFF
--- a/EverythingToolbar/Controls/SearchResultsView.xaml.cs
+++ b/EverythingToolbar/Controls/SearchResultsView.xaml.cs
@@ -238,16 +238,16 @@ namespace EverythingToolbar.Controls
             if (SearchResultsListView.SelectedIndex == -1)
                 return;
 
+            SearchWindow.Instance.Hide();
+
             if (!Rules.HandleRule(SelectedItem))
                 SelectedItem?.Open();
-
-            SearchWindow.Instance.Hide();
         }
 
         private void OpenFilePath(object sender, RoutedEventArgs e)
         {
-            SelectedItem?.OpenPath();
             SearchWindow.Instance.Hide();
+            SelectedItem?.OpenPath();
         }
 
         private void PreviewSelectedFile()


### PR DESCRIPTION
Hide after clicking a program icon like Windows Search, instead of waiting for it to start.