### PR TITLE
Fixes #481 - Keep selected filter option between application restarts.

### DIFF
--- a/EverythingToolbar/Controls/FilterSelector.xaml
+++ b/EverythingToolbar/Controls/FilterSelector.xaml
@@ -6,13 +6,13 @@
             BorderThickness="0, 0, 0, 1">
         <StackPanel Orientation="Horizontal">
             <TabControl x:Name="TabControl"
-                        SelectionChanged="OnTabItemSelected"
-                        ItemsSource="{Binding DefaultFilters}" />
+                        ItemsSource="{Binding DefaultFilters}"
+                        SelectedIndex="-1" />
 
             <ComboBox Name="ComboBox"
-                      SelectionChanged="OnComboBoxItemSelected"
                       ItemsSource="{Binding UserFilters}"
-                      DisplayMemberPath="Name" />
+                      DisplayMemberPath="Name"
+                      SelectedIndex="-1" />
         </StackPanel>
     </Border>
     

--- a/EverythingToolbar/Controls/FilterSelector.xaml.cs
+++ b/EverythingToolbar/Controls/FilterSelector.xaml.cs
@@ -11,18 +11,29 @@ namespace EverythingToolbar.Controls
         {
             InitializeComponent();
             DataContext = FilterLoader.Instance;
-            EverythingSearch.Instance.PropertyChanged += OnCurrentFilterChanged;
-            Loaded += (s, e) => { SelectCurrentFilter(); };
+            Loaded += (s, e) => {
+                SelectCurrentFilter();
+                EverythingSearch.Instance.PropertyChanged += OnCurrentFilterChanged;
+            };
         }
 
+        public int SelectedDefaultFilterIndex
+        {
+            get => FilterLoader.Instance.DefaultFilters.IndexOf(EverythingSearch.Instance.CurrentFilter);
+        }
+
+        public int SelectedUserFilterIndex
+        {
+            get => FilterLoader.Instance.UserFilters.IndexOf(EverythingSearch.Instance.CurrentFilter);
+        }
         private void SelectCurrentFilter()
         {
             TabControl.SelectionChanged -= OnTabItemSelected;
-            TabControl.SelectedIndex = FilterLoader.Instance.DefaultFilters.IndexOf(EverythingSearch.Instance.CurrentFilter);
+            TabControl.SelectedIndex = SelectedDefaultFilterIndex;
             TabControl.SelectionChanged += OnTabItemSelected;
 
             ComboBox.SelectionChanged -= OnComboBoxItemSelected;
-            ComboBox.SelectedIndex = FilterLoader.Instance.UserFilters.IndexOf(EverythingSearch.Instance.CurrentFilter);
+            ComboBox.SelectedIndex = SelectedUserFilterIndex;
             ComboBox.SelectionChanged += OnComboBoxItemSelected;
         }
 
@@ -39,6 +50,11 @@ namespace EverythingToolbar.Controls
             if (TabControl.SelectedIndex < 0)
                 return;
 
+            if (!TabControl.IsFocused && !TabControl.IsMouseOver) {
+                TabControl.SelectedIndex = -1;
+                return;
+            }
+
             EverythingSearch.Instance.CurrentFilter = TabControl.SelectedItem as Filter;
         }
 
@@ -46,6 +62,11 @@ namespace EverythingToolbar.Controls
         {
             if (ComboBox.SelectedIndex < 0)
                 return;
+
+            if (!ComboBox.IsFocused && !ComboBox.IsMouseOver) { 
+                ComboBox.SelectedIndex = -1;
+                return;
+            }
 
             EverythingSearch.Instance.CurrentFilter = ComboBox.SelectedItem as Filter;
         }

--- a/EverythingToolbar/EverythingSearch.cs
+++ b/EverythingToolbar/EverythingSearch.cs
@@ -74,7 +74,7 @@ namespace EverythingToolbar
                     SearchResults.Clear();
                 QueryBatch(append: false);
 
-                NotifyPropertyChanged("CurrentFilter");
+                NotifyPropertyChanged();
             }
         }
 

--- a/EverythingToolbar/EverythingSearch.cs
+++ b/EverythingToolbar/EverythingSearch.cs
@@ -68,12 +68,13 @@ namespace EverythingToolbar
                     return;
 
                 _currentFilter = value;
+                Settings.Default.lastFilter = value.Name;
                 
                 lock (_lock)
                     SearchResults.Clear();
                 QueryBatch(append: false);
 
-                NotifyPropertyChanged();
+                NotifyPropertyChanged("CurrentFilter");
             }
         }
 


### PR DESCRIPTION
This PR fixes https://github.com/srwi/EverythingToolbar/issues/481 so the selected filter is saved on selection change, and updates the tab and combo to only update if the element is under the mouse cursor or focused.

I implemented it this way because I'm not familiar with `C#` and couldn't figure out why on `Show()` it would fire the SelectionChanged event...In the code there should be nothing triggering it (it kept defaulting back to `All` even though when I was debugging, the `Settings.Default.lastFilter` showed the correctly selected filter.

Anyway, if you have a suggestion on how to avoid that issue and maybe bind the `SelectedIndex` directly (I tried that and it still fired on `Show()`) let me know, and I will update the PR, otherwise, this works. :)