### PR TITLE
Fix jagged tray icons by replacing WPF-UI.Tray with NativeTray

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <PackageVersion Include="NHotkey.Wpf" Version="3.0.0" />
     <PackageVersion Include="NLog" Version="5.1.1" />
+    <PackageVersion Include="NativeTray" Version="2.2.3" />
     <PackageVersion Include="WPF-UI" Version="4.0.3" />
-    <PackageVersion Include="WPF-UI.Tray" Version="4.0.3" />
   </ItemGroup>
 </Project>

--- a/EverythingToolbar.Launcher/EverythingToolbar.Launcher.csproj
+++ b/EverythingToolbar.Launcher/EverythingToolbar.Launcher.csproj
@@ -69,7 +69,7 @@
     </COMReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="WPF-UI.Tray" />
+    <PackageReference Include="NativeTray" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" />
     <PackageReference Include="NLog" />
     <PackageReference Include="Microsoft.Windows.CsWin32">

--- a/EverythingToolbar.Launcher/Launcher.cs
+++ b/EverythingToolbar.Launcher/Launcher.cs
@@ -195,8 +195,7 @@ namespace EverythingToolbar.Launcher
             {
                 if (_taskbarCreatedMsg != 0 && msg == _taskbarCreatedMsg)
                 {
-                    // Explorer restarted and dropped the tray icon; TaskbarCreated signals it's ready again.
-                    TrayIcon?.HandleExplorerRestart();
+                    // Explorer restarted; TaskbarCreated signals it's ready again.
                     _taskbarWindowHost.HandleExplorerRestart();
                 }
 

--- a/EverythingToolbar.Launcher/Launcher.cs
+++ b/EverythingToolbar.Launcher/Launcher.cs
@@ -292,11 +292,7 @@ namespace EverythingToolbar.Launcher
                     );
 
                     var app = new Application();
-                    using var trayIcon = new TrayIcon(
-                        OpenSettingsWindow,
-                        app.Shutdown,
-                        Ioc.Default.GetRequiredService<ThemeService>()
-                    );
+                    using var trayIcon = new TrayIcon(OpenSettingsWindow, app.Shutdown);
                     app.Run(new LauncherWindow(trayIcon));
                 }
                 else

--- a/EverythingToolbar.Launcher/TrayIcon.cs
+++ b/EverythingToolbar.Launcher/TrayIcon.cs
@@ -1,67 +1,78 @@
 using System;
-using System.Windows.Controls;
-using System.Windows.Media.Imaging;
+using System.IO;
+using System.NativeTray;
+using System.Windows;
 using EverythingToolbar.Launcher.Properties;
-using Wpf.Ui.Appearance;
-using Wpf.Ui.Markup;
-using NotifyIcon = Wpf.Ui.Tray.Controls.NotifyIcon;
 
 namespace EverythingToolbar.Launcher
 {
     internal sealed class TrayIcon : IDisposable
     {
-        private readonly NotifyIcon _notifyIcon;
-        private readonly ThemeService _themeService;
-        private readonly ThemesDictionary _menuTheme;
+        private readonly TrayIconHost _notifyIcon;
+        private Win32Icon? _iconSource;
 
-        public TrayIcon(Action onOpenSettings, Action onQuit, ThemeService themeService)
+        public TrayIcon(Action onOpenSettings, Action onQuit)
         {
-            _themeService = themeService;
-            var contextMenu = new ContextMenu();
-
-            var settingsItem = new MenuItem { Header = Resources.ContextMenuSettings };
-            settingsItem.Click += (_, _) => onOpenSettings();
-            contextMenu.Items.Add(settingsItem);
-
-            var quitItem = new MenuItem { Header = Resources.ContextMenuQuit };
-            quitItem.Click += (_, _) => onQuit();
-            contextMenu.Items.Add(quitItem);
-
-            _menuTheme = new ThemesDictionary
+            _notifyIcon = new TrayIconHost
             {
-                Theme = ToApplicationTheme(_themeService.GetEffectiveTheme(ThemeFlavor.App)),
+                ToolTipText = "EverythingToolbar",
+                ThemeMode = TrayThemeMode.System,
+                IconSource = _iconSource = CreateThemedIcon(),
+                IsVisible = false,
+                Menu = new TrayMenu
+                {
+                    new TrayMenuItem
+                    {
+                        Header = Resources.ContextMenuSettings,
+                        Command = new TrayCommand(_ => Dispatch(onOpenSettings)),
+                    },
+                    new TrayMenuItem
+                    {
+                        Header = Resources.ContextMenuQuit,
+                        Command = new TrayCommand(_ => Dispatch(onQuit)),
+                    },
+                },
             };
-            contextMenu.Resources.MergedDictionaries.Add(new ControlsDictionary());
-            contextMenu.Resources.MergedDictionaries.Add(_menuTheme);
-            _themeService.ThemeChanged += OnThemeChanged;
 
-            _notifyIcon = new NotifyIcon
-            {
-                Icon = new BitmapImage(new Uri(Utils.GetThemedAppIconPath(absolute: true))),
-                Menu = contextMenu,
-            };
+            _notifyIcon.UserPreferenceChanged += OnUserPreferenceChanged;
         }
 
-        public void Show() => _notifyIcon.Register();
+        public void Show() => _notifyIcon.IsVisible = true;
 
-        public void Hide() => _notifyIcon.Unregister();
+        public void Hide() => _notifyIcon.IsVisible = false;
 
-        public void HandleExplorerRestart()
-        {
-            if (_notifyIcon.IsRegistered)
-                _notifyIcon.Register();
-        }
+        // NativeTray already re-adds the icon on TaskbarCreated.
+        public void HandleExplorerRestart() { }
 
         public void Dispose()
         {
-            _themeService.ThemeChanged -= OnThemeChanged;
+            _notifyIcon.UserPreferenceChanged -= OnUserPreferenceChanged;
             _notifyIcon.Dispose();
+            _iconSource?.Dispose();
+            _iconSource = null;
         }
 
-        private void OnThemeChanged(object? sender, ThemeChangedEventArgs e) =>
-            _menuTheme.Theme = ToApplicationTheme(e.AppTheme);
+        private void OnUserPreferenceChanged(object? sender, EventArgs e) => ApplyThemedIcon();
 
-        private static ApplicationTheme ToApplicationTheme(Theme theme) =>
-            theme == Theme.Light ? ApplicationTheme.Light : ApplicationTheme.Dark;
+        private void ApplyThemedIcon()
+        {
+            var next = CreateThemedIcon();
+            var previous = _iconSource;
+            _iconSource = next;
+            _notifyIcon.IconSource = next;
+            previous?.Dispose();
+        }
+
+        private static Win32Icon CreateThemedIcon() =>
+            new(File.ReadAllBytes(Utils.GetThemedAppIconPath(absolute: true)));
+
+        private static void Dispatch(Action action)
+        {
+            var dispatcher = Application.Current?.Dispatcher;
+            if (dispatcher == null || dispatcher.CheckAccess())
+                action();
+            else
+                dispatcher.BeginInvoke(action);
+        }
     }
 }

--- a/EverythingToolbar.Launcher/TrayIcon.cs
+++ b/EverythingToolbar.Launcher/TrayIcon.cs
@@ -41,9 +41,6 @@ namespace EverythingToolbar.Launcher
 
         public void Hide() => _notifyIcon.IsVisible = false;
 
-        // NativeTray already re-adds the icon on TaskbarCreated.
-        public void HandleExplorerRestart() { }
-
         public void Dispose()
         {
             _notifyIcon.UserPreferenceChanged -= OnUserPreferenceChanged;


### PR DESCRIPTION
﻿## Checklist

- [x] I have read the [contribution guidelines](https://github.com/srwi/EverythingToolbar/blob/develop/CONTRIBUTING.md)

## Summary

**This change is strongly needed.** The current WPF-UI.Tray tray icon path produces visibly jagged icons in the Windows tray overflow, which looks broken next to other native tray apps.

Why this fix matters:

1. **Fixes WPF-UI.Tray aliasing** — WPF-UI.Tray converts the icon through `Bitmap.GetHicon()`, which strips alpha anti-aliasing. NativeTray selects the correct ICO frame for `SM_CXSMICON` / DPI and keeps alpha, so edges stay crisp.
2. **Native Win32 context menu** — Replaces the WPF-styled tray menu with a native menu for a more authentic Windows experience (same approach PowerToys uses for tray menus).
3. **Built-in dark mode** — NativeTray already adapts the tray menu to system light/dark theme (`TrayThemeMode.System`), so no extra theme wiring is required on our side.

Replaces `WPF-UI.Tray` with [NativeTray](https://www.nuget.org/packages/NativeTray) `2.2.3` in the Launcher.

## Related issue

No existing issue. Local tray overflow screenshot shows severe aliasing on the EverythingToolbar magnifying-glass icon (attached in Screenshots).

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] UI change
- [ ] Documentation update
- [x] Refactoring / maintenance

## Testing

- [x] Built `EverythingToolbar.Launcher` (Debug | x64)
- [ ] Manually verified tray icon sharpness in Windows 11 tray overflow (light/dark)
- [ ] Manually verified Settings / Quit native context menu
- [ ] Manually verified tray icon show/hide and Explorer restart recovery

## Screenshots or recordings

Before (WPF-UI.Tray — jagged edges): see comment below with the tray overflow screenshot.
